### PR TITLE
Various improvements

### DIFF
--- a/checker.d
+++ b/checker.d
@@ -516,8 +516,8 @@ class Checker {
 				return;
 		}
 
-		if(e.substitute) {
-			visExpr(e.getInitializer());
+		if(auto init=e.getInitializer()) {
+			visExpr(init);
 			return;
 		}
 

--- a/conversion.d
+++ b/conversion.d
@@ -316,9 +316,9 @@ Ret!witness tupleToTuple(bool witness)(Expression from,Expression to,TypeAnnotat
 }
 
 class FunctionConversion: Conversion{
-	string[] names;
+	Id[] names;
 	Conversion dom,cod;
-	this(ProductTy from,ProductTy to,string[] names,Conversion dom,Conversion cod)in{
+	this(ProductTy from,ProductTy to,Id[] names,Conversion dom,Conversion cod)in{
 		assert(isNoOpConversion(to.dom,dom.from)&&isNoOpConversion(dom.to,from.dom));
 		assert(from.names==names&&to.names==names);
 		assert(isNoOpConversion(cod.from,from.cod)&&isNoOpConversion(to.cod,cod.to),text(to.cod," ",cod.to));
@@ -356,7 +356,7 @@ Ret!witness functionToFunction(bool witness)(Expression from,Expression to,TypeA
 	}
 	if(!equal(ft1.isConstForSubtyping,ft2.isConstForSubtyping)) return typeof(return).init;
 	if(ft1.names.length!=ft2.names.length) return typeof(return).init;
-	string[] names;
+	Id[] names;
 	if(ft1.names!=ft2.names){
 		names=ft1.freshNames(ft2);
 	}else names=ft1.names;

--- a/declaration.d
+++ b/declaration.d
@@ -250,14 +250,14 @@ class DatDecl: Declaration{
 	override bool isCompound(){ return true; }
 	override bool isLinear(){ return false; }
 
-	final Expression[string] getSubst(Expression arg){
-		Expression[string] subst;
+	final Expression[Id] getSubst(Expression arg){
+		Expression[Id] subst;
 		if(isTuple){
 			foreach(i,p;params)
-				subst[p.getName]=new IndexExp(arg,new LiteralExp(Token(Tok!"0",to!string(i)))).eval();
+				subst[p.getId]=new IndexExp(arg,new LiteralExp(Token(Tok!"0",to!string(i)))).eval();
 		}else{
 			assert(params.length==1);
-			subst[params[0].getName]=arg;
+			subst[params[0].getId]=arg;
 		}
 		return subst;
 	}

--- a/lexer.d
+++ b/lexer.d
@@ -256,6 +256,10 @@ struct Location{
 		if(rep.ptr>end.rep.ptr+end.rep.length) return cast()this;
 		return Location(rep.ptr[0..end.rep.ptr-rep.ptr+end.rep.length],line);
 	}
+	string toString(){
+		if(!rep) return "<??>";
+		return format("%s:%s <%s>", source.name, line, rep);
+	}
 }
 import std.array;
 int getColumn(Location loc, int tabsize){

--- a/lowerings.d
+++ b/lowerings.d
@@ -5,6 +5,7 @@ import std.algorithm, std.conv,std.exception;
 import astopt;
 import ast.lexer,ast.scope_,ast.error;
 import ast.type,ast.expression,ast.semantic_;
+import ast.declaration;
 
 static if(language==silq):
 
@@ -21,6 +22,15 @@ Scope getOperatorScope(Location loc,ErrorHandler err){
 	int nerr=err.nerrors;
 	exprs=semantic(exprs,opsc);
 	return opsc;
+}
+
+bool isInOperators(Declaration decl){
+	static if(operatorLowering) {
+		if(!opsc) return false;
+		return decl.scope_.isNestedIn(opsc);
+	} else {
+		return false;
+	}
 }
 
 Identifier getOperatorSymbol(string name,Location loc,Scope isc){

--- a/semantic_.d
+++ b/semantic_.d
@@ -585,6 +585,15 @@ string isPrimitive(Expression e){
 	return opLit.lit.str;
 }
 
+// TODO `class PrimitiveExp: Expression { string prim; Expression[] args; Annotation annotation; }`
+static if(language==silq)
+string isPrimitiveCall(Expression e){
+	auto ce=cast(CallExp)e;
+	if(!ce) return null;
+	if(ce.isSquare || ce.isClassical_) return null;
+	return isPrimitive(ce.e);
+}
+
 bool isInPrelude(){
 	auto exprssc=modules[preludePath()];
 	return exprssc[1] is null;

--- a/semantic_.d
+++ b/semantic_.d
@@ -3364,14 +3364,6 @@ Expression expressionSemanticImpl(Identifier id,ExpSemContext context){
 			}
 		}
 	}
-	auto vd=cast(VarDecl)meaning;
-	if(vd){
-		if(cast(TopScope)vd.scope_||isTypeTy(vd.vtype)&&vd.initializer){
-			if(!vd.initializer||vd.initializer.sstate!=SemState.completed)
-				id.sstate=SemState.error;
-			id.substitute=true;
-		}
-	}
 	return dupIfNeeded(id);
 }
 


### PR DESCRIPTION
- Various helper functions
- `string` -> `Id` in more places
- Global constant initializers can now refer to functions
- `__primitive` functions are always `isTuple`; also make it easier to maybe switch to a `PrimitiveExp` AST node in the future

The Silq changes are in https://github.com/hvenev-insait/silq/commit/544530a214a7e413f2c21f2aafd858a8e97baf0c, which you should be able to access. I cannot open a PR because it's a private repo.