### PR TITLE
Add function attributes, mark multi-parameter wrappers `@artificial`

### DIFF
--- a/declaration.d
+++ b/declaration.d
@@ -139,6 +139,7 @@ class FunctionDef: Declaration{
 		auto r=new FunctionDef(name?name.copy(args):null,params.map!(p=>p.copy(args)).array,isTuple,rret?rret.copy(args):null,body_?body_.copy(args):null);
 		r.isSquare=isSquare;
 		r.annotation=annotation;
+		r.attributes=attributes.array;
 		return r;
 	}
 	override string toString(){
@@ -172,6 +173,7 @@ class FunctionDef: Declaration{
 	bool hasReturn;
 	bool isConstructor;
 	string[] retNames;
+	string[] attributes;
 
 	void seal(){
 		sealedLinearCaptures=true;
@@ -192,6 +194,10 @@ class FunctionDef: Declaration{
 	@property size_t numReturns(){
 		if(!ftype) return 0;
 		return ftype.cod.numComponents;
+	}
+
+	bool hasAttribute(string attr) {
+		return attributes.any!(a => a == attr);
 	}
 
 	FunctionDef reversed=null;

--- a/parser.d
+++ b/parser.d
@@ -801,6 +801,11 @@ struct Parser{
 		expect(isSquare?Tok!"]":Tok!")");
 		auto annotation=Annotation.none;
 		bool isLifted=false;
+		auto attributes=appender!(string[]);
+		while(ttype==Tok!"@"){
+			attributes.put(tok.name);
+			nextToken();
+		}
 		static if(language==silq){
 			if(ttype==Tok!"lifted"||ttype==Tok!"qfree"){
 				isLifted=ttype==Tok!"lifted";
@@ -830,6 +835,7 @@ struct Parser{
 			Expression e;
 			if(ttype==Tok!"("||ttype==Tok!"["){
 				if(annotation==Annotation.none) annotation=pure_;
+				attributes.put("artificial");
 				e=parseLambdaExp!semicolon();
 			}else{
 				nextToken();
@@ -847,6 +853,7 @@ struct Parser{
 		res=New!FunctionDef(name,cast(Parameter[])params[0],params[1]||params[0].length!=1,ret,body_);
 		res.isSquare=isSquare;
 		res.annotation=annotation;
+		res.attributes=attributes[];
 		return res;
 	}
 	DatParameter parseDatParameter(bool constDefault){


### PR DESCRIPTION
This can be used as a hint to the frontend to do inlining during code generation. Also, we can omit artificial functions from stack traces instead of relying on heuristics such as `isInPrelude`.